### PR TITLE
Declare moment.js dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,6 +10,7 @@ Package.onUse(function (api) {
   api.use([
     'underscore',
     'templating',
+    'momentjs:moment',
     'aldeed:tabular@1.4.0',
     'aldeed:template-extension@3.4.3',
     'vsivsi:job-collection@1.2.3'

--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function (api) {
   api.use([
     'underscore',
     'templating',
-    'momentjs:moment',
+    'momentjs:moment@2.10.6',
     'aldeed:tabular@1.4.0',
     'aldeed:template-extension@3.4.3',
     'vsivsi:job-collection@1.2.3'


### PR DESCRIPTION
This package uses moment.js [here](https://github.com/DispatchMe/meteor-tabular-job-collection/blob/master/lib/both/tabular-job-collection.js#L29) but doesn't declare it as a dependency, so I was getting errors. This fixes that.
